### PR TITLE
Don't run napari cell by default

### DIFF
--- a/notebooks/opening_images.ipynb
+++ b/notebooks/opening_images.ipynb
@@ -463,6 +463,7 @@
    },
    "outputs": [],
    "source": [
+    "%%script false --no-raise-error\n",
     "import napari\n",
     "import dask.array as da\n",
     "\n",


### PR DESCRIPTION
This means you can run `jupyter nbconvert --execute opening_images.ipynb --to notebook` without an error