### PR TITLE
Labeled image truncation

### DIFF
--- a/notebooks/working_with_objects.ipynb
+++ b/notebooks/working_with_objects.ipynb
@@ -231,6 +231,7 @@
     "# Request the pixel values of the entire labeled image. Pixel values will be created as they are requested \n",
     "label_image = labeled_server.read_region()\n",
     "\n",
+    "\n",
     "# label_image is an image of shape (c, y, x), not easily plottable\n",
     "# We use a utility function from qubalab to plot the image\n",
     "from qubalab.display.plot import plotImage\n",
@@ -497,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/qubalab/images/image_server.py
+++ b/qubalab/images/image_server.py
@@ -70,7 +70,6 @@ class ImageServer(ABC):
                  pixel located at coordinates [x, y] on the image
         :raises ValueError: when the region to read is not specified
         """
-
         if region is None:
             region = Region2D(x=x, y=y, width=width, height=height, z=z, t=t)
         elif isinstance(region, tuple):

--- a/qubalab/images/labeled_server.py
+++ b/qubalab/images/labeled_server.py
@@ -34,7 +34,7 @@ class LabeledImageServer(ImageServer):
         """
         :param base_image_metadata: the metadata of the image containing the image features
         :param features: the image features to draw
-        :param label_map: a dictionnary mapping a classification to a label. The value of pixels where an image feature with
+        :param label_map: a dictionary mapping a classification to a label. The value of pixels where an image feature with
                           a certain classification is present will be taken from this dictionnary. If not provided, each feature
                           will be assigned a unique integer. All labels must be greater than 0 
         :param downsample: the downsample to apply to the image. Can be omitted to use the full resolution image
@@ -88,7 +88,7 @@ class LabeledImageServer(ImageServer):
                 self._base_image_metadata.pixel_calibration.length_z
             ),
             False,
-            bool if self._multichannel else np.uint
+            bool if self._multichannel else np.uint32
         )
 
     def _read_block(self, level: int, region: Region2D) -> np.ndarray:
@@ -113,9 +113,8 @@ class LabeledImageServer(ImageServer):
 
             return full_image
         else:
-            image = PIL.Image.new('P', (region.width, region.height))
+            image = PIL.Image.new('I', (region.width, region.height))
             drawing_context = PIL.ImageDraw.Draw(image)
-
             for i in self._tree.query(region.geometry):
                 draw_geometry(
                     image.size,
@@ -123,5 +122,4 @@ class LabeledImageServer(ImageServer):
                     self._geometries[i],
                     self._feature_index_to_label[i]
                 )
-
             return np.expand_dims(np.asarray(image, dtype=self.metadata.dtype), axis=0)

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -384,9 +384,10 @@ def test_read_polygon_in_single_channel_image_without_label_map_with_downsample(
 
 def test_label_can_hold_many_values():
     downsample = 2
-    features = [ImageFeature(geojson.Polygon([[(6, 2), (8, 2), (8, 4), (4, 4)]]), Classification("Some classification")) for i in range(1000)]
+    n_objects = 1000
+    features = [ImageFeature(geojson.Polygon([[(6, 2), (8, 2), (8, 4), (4, 4)]]), Classification("Some classification")) for i in range(n_objects)]
     labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=downsample)
 
     image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
 
-    assert np.max(image), 1000
+    assert np.max(image), n_objects

--- a/tests/images/test_labeled_server.py
+++ b/tests/images/test_labeled_server.py
@@ -183,7 +183,7 @@ def test_x_pixel_length_with_no_downsample():
 
 
 def test_dtype_when_not_multi_channel():
-    expected_dtype = np.uint
+    expected_dtype = np.uint32
     labeled_server = LabeledImageServer(sample_metadata, [], multichannel=False)
 
     dtype = labeled_server.metadata.dtype
@@ -381,3 +381,12 @@ def test_read_polygon_in_single_channel_image_without_label_map_with_downsample(
     image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
 
     np.testing.assert_array_equal(image, expected_image)
+
+def test_label_can_hold_many_values():
+    downsample = 2
+    features = [ImageFeature(geojson.Polygon([[(6, 2), (8, 2), (8, 4), (4, 4)]]), Classification("Some classification")) for i in range(1000)]
+    labeled_server = LabeledImageServer(sample_metadata, features, multichannel=False, downsample=downsample)
+
+    image = labeled_server.read_region(1, Region2D(0, 0, labeled_server.metadata.width, labeled_server.metadata.height))
+
+    assert np.max(image), 1000


### PR DESCRIPTION
Labelled images were being coerced to uint8 so only 255 objects.