### PR TITLE
BioIO links and functionality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install
         run: pip install .[test]

--- a/qubalab/images/bioio_server.py
+++ b/qubalab/images/bioio_server.py
@@ -13,7 +13,7 @@ from .region_2d import Region2D
 
 class BioIOServer(ImageServer):
     """
-    An ImageServer using BioIO (https://github.com/AllenCellModeling/BioIO).
+    An ImageServer using BioIO (https://github.com/bioio-devs/bioio).
 
     What this actually supports will depend upon how BioIO is installed.
     For example, it may provide Bio-Formats or CZI support... or it may not.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qubalab
-version = 0.1.0
+version = 0.1.1
 description = A laboratory for exploring quantitative bioimage analysis in Python
 author = Pete Bankhead, Alan O'Callaghan, Léo Leplat
 license = Apache-2.0
@@ -20,10 +20,10 @@ packages =
     qubalab.qupath
 python_requires = >= 3.10
 install_requires =
-    tiffslide ~= 2.4.0
-    bioio ~= 1.1.0
-    bioio-ome-zarr ~= 1.0.1
-    bioio-ome-tiff ~= 1.0.1
+    tiffslide ~= 2.5.1
+    bioio ~= 3.0.0
+    bioio-ome-zarr ~= 1.2.0
+    bioio-ome-tiff ~= 1.4.0
     dask-image >= 0.6.0
     py4j ~= 0.10.9.7
     geojson ~= 3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ packages =
     qubalab.images.metadata
     qubalab.objects
     qubalab.qupath
-python_requires = >= 3.10
+python_requires = >= 3.11
 install_requires =
-    tiffslide ~= 2.5.1
+    tiffslide ~= 2.4.0
     bioio ~= 3.0.0
-    bioio-ome-zarr ~= 1.2.0
+    bioio-ome-zarr ~= 2.3.0
     bioio-ome-tiff ~= 1.4.0
     dask-image >= 0.6.0
     py4j ~= 0.10.9.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,11 @@ packages =
     qubalab.qupath
 python_requires = >= 3.11
 install_requires =
-    tiffslide ~= 2.4.0
     bioio ~= 3.0.0
     bioio-ome-zarr ~= 2.3.0
     bioio-ome-tiff ~= 1.4.0
+    tifffile <= 2025.9.9
+    tiffslide ~= 2.4.0
     dask-image >= 0.6.0
     py4j ~= 0.10.9.7
     geojson ~= 3.1.0

--- a/tests/res/single_resolution_float_5d_zarr.py
+++ b/tests/res/single_resolution_float_5d_zarr.py
@@ -51,7 +51,9 @@ def _write_image(pixels: np.array):
     if os.path.exists(get_path()) and os.path.isdir(get_path()):
         shutil.rmtree(get_path())
 
-    zarr = bioio.writers.OMEZarrWriter(get_path())
+    zarr = bioio.writers.OMEZarrWriter(
+        get_path(), dtype=get_dtype(), shape=get_shapes()[0]
+    )
     zarr.write_image(
         image_data=pixels,
         image_name="single_resolution_float_5d",

--- a/tests/res/single_resolution_float_5d_zarr.py
+++ b/tests/res/single_resolution_float_5d_zarr.py
@@ -52,7 +52,7 @@ def _write_image(pixels: np.array):
         shutil.rmtree(get_path())
 
     zarr = bioio.writers.OMEZarrWriter(
-        get_path(), dtype=get_dtype(), shape=get_shapes()[0]
+        get_path(), dtype=get_dtype(), shape=get_shapes()[0].as_tuple()
     )
     zarr.write_image(
         image_data=pixels,

--- a/tests/res/single_resolution_float_5d_zarr.py
+++ b/tests/res/single_resolution_float_5d_zarr.py
@@ -11,7 +11,9 @@ def get_name() -> str:
 
 
 def get_path() -> str:
-    return os.path.realpath(os.path.join(os.path.realpath(__file__), os.pardir, get_name()))
+    return os.path.realpath(
+        os.path.join(os.path.realpath(__file__), os.pardir, get_name())
+    )
 
 
 def get_shapes() -> tuple[ImageShape, ...]:
@@ -35,7 +37,13 @@ def get_pixel_value(x: int, y: int, c: int, z: int, t: int) -> int:
 
 
 def _get_pixels() -> np.array:
-    return np.random.rand(get_shapes()[0].t, get_shapes()[0].c, get_shapes()[0].z, get_shapes()[0].y, get_shapes()[0].x)
+    return np.random.rand(
+        get_shapes()[0].t,
+        get_shapes()[0].c,
+        get_shapes()[0].z,
+        get_shapes()[0].y,
+        get_shapes()[0].x,
+    )
 
 
 def _write_image(pixels: np.array):
@@ -43,16 +51,17 @@ def _write_image(pixels: np.array):
     if os.path.exists(get_path()) and os.path.isdir(get_path()):
         shutil.rmtree(get_path())
 
-    zarr = bioio.writers.OmeZarrWriter(get_path())
+    zarr = bioio.writers.OMEZarrWriter(get_path())
     zarr.write_image(
-        image_data = pixels,
-        image_name = "single_resolution_float_5d",
-        channel_names = ["Channel " + str(i) for i in range(get_shapes()[0].c)],
-        channel_colors = [i for i in range(get_shapes()[0].c)],
-        physical_pixel_sizes = PhysicalPixelSizes(
-            X = get_pixel_size_x_y_in_micrometers(),
-            Y = get_pixel_size_x_y_in_micrometers(),
-            Z = get_pixel_size_x_y_in_micrometers())
+        image_data=pixels,
+        image_name="single_resolution_float_5d",
+        channel_names=["Channel " + str(i) for i in range(get_shapes()[0].c)],
+        channel_colors=[i for i in range(get_shapes()[0].c)],
+        physical_pixel_sizes=PhysicalPixelSizes(
+            X=get_pixel_size_x_y_in_micrometers(),
+            Y=get_pixel_size_x_y_in_micrometers(),
+            Z=get_pixel_size_x_y_in_micrometers(),
+        ),
     )
 
 


### PR DESCRIPTION
Currently having issues with BioIO server and noticed a broken link.

Also could consider a generic `createImageServer` method that will return an ImageServer of suitable type, without the user needing to specify which library is used internally (which seems like an implementation detail?).